### PR TITLE
Added a class for -latest

### DIFF
--- a/ripe/atlas/cousteau/__init__.py
+++ b/ripe/atlas/cousteau/__init__.py
@@ -13,6 +13,7 @@ from .request import (
     AtlasCreateRequest,
     AtlasChangeRequest,
     AtlasStopRequest,
+    AtlasLatestRequest,
     AtlasResultsRequest
 )
 from .stream import AtlasStream

--- a/ripe/atlas/cousteau/__init__.py
+++ b/ripe/atlas/cousteau/__init__.py
@@ -279,6 +279,7 @@ __all__ = [
     "AtlasChangeRequest",
     "AtlasCreateRequest",
     "AtlasStopRequest",
+    "AtlasLatestRequest",
     "AtlasResultsRequest",
     "AtlasSource",
     "AtlasChangeSource",

--- a/ripe/atlas/cousteau/request.py
+++ b/ripe/atlas/cousteau/request.py
@@ -231,7 +231,7 @@ class AtlasLatestRequest(AtlasRequest):
 
         self.url_path = self.url_path.format(self.msm_id)
         if self.probe_ids:
-            self.url_path += "?probe_ids={}".format(
+            self.url_path += "?probe_ids={0}".format(
                 ",".join([str(_) for _ in self.probe_ids])
             )
 

--- a/ripe/atlas/cousteau/request.py
+++ b/ripe/atlas/cousteau/request.py
@@ -220,6 +220,24 @@ class AtlasStopRequest(AtlasRequest):
         return self.delete()
 
 
+class AtlasLatestRequest(AtlasRequest):
+
+    url_path = "/api/v2/measurements/{0}/latest"
+
+    def __init__(self, msm_id=None, probe_ids=(), **kwargs):
+
+        self.msm_id = msm_id
+        self.probe_ids = probe_ids
+
+        self.url_path = self.url_path.format(self.msm_id)
+        if self.probe_ids:
+            self.url_path += "?probe_ids={}".format(
+                ",".join([str(_) for _ in self.probe_ids])
+            )
+
+        super(AtlasLatestRequest, self).__init__(**kwargs)
+
+
 class AtlasResultsRequest(AtlasRequest):
     """Atlas request for fetching results of a measurement."""
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -10,7 +10,7 @@ from ripe.atlas.cousteau import (
     Ping,
     AtlasSource, AtlasChangeSource,
     AtlasCreateRequest, AtlasChangeRequest,
-    AtlasResultsRequest, RequestGenerator, ProbeRequest,
+    AtlasLatestRequest, AtlasResultsRequest, RequestGenerator, ProbeRequest,
     Probe, Measurement
 )
 from ripe.atlas.cousteau.exceptions import APIResponseError
@@ -97,6 +97,25 @@ class TestAtlasResultsRequest(unittest.TestCase):
         self.assertTrue(re.match(r"^\d+.\d+$", query_filters["stop"][0]))
         self.assertTrue(
             re.match(r"^(\d+,)+\d+$", query_filters["prb_id"][0])
+        )
+
+
+class TestAtlasLatestRequest(unittest.TestCase):
+
+    def setUp(self):
+        self.request = AtlasResultsRequest(**{
+            "msm_id": 1000002,
+            "probe_ids": [1, 2, 3]
+        })
+
+    def test_url_path_permutations(self):
+        self.assertEqual(
+            AtlasLatestRequest(msm_id=1001),
+            "/api/v2/measurements/1001/latest"
+        )
+        self.assertEqual(
+            AtlasLatestRequest(msm_id=1001, probe_ids=(1, 2, 3)),
+            "/api/v2/measurements/1001/latest?probe_ids=1,2,3"
         )
 
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -110,11 +110,11 @@ class TestAtlasLatestRequest(unittest.TestCase):
 
     def test_url_path_permutations(self):
         self.assertEqual(
-            AtlasLatestRequest(msm_id=1001),
+            AtlasLatestRequest(msm_id=1001).url_path,
             "/api/v2/measurements/1001/latest"
         )
         self.assertEqual(
-            AtlasLatestRequest(msm_id=1001, probe_ids=(1, 2, 3)),
+            AtlasLatestRequest(msm_id=1001, probe_ids=(1, 2, 3)).url_path,
             "/api/v2/measurements/1001/latest?probe_ids=1,2,3"
         )
 


### PR DESCRIPTION
This should make work on Magellan easier.

For the record though, I'm not thrilled about this defining `url_path=` as a constant (outside of __init__) only to modify it later.  It's the pattern that was there already though, so I didn't want to deviate.