### PR TITLE
The Python datetime objects were getting serialised in a less-than-useful fashion

### DIFF
--- a/ripe/atlas/cousteau/__init__.py
+++ b/ripe/atlas/cousteau/__init__.py
@@ -5,7 +5,7 @@ except ImportError:
     # Python 2
     from urlparse import urlparse
 
-import time
+import calendar
 
 from datetime import datetime
 
@@ -164,7 +164,7 @@ class RequestGenerator(object):
         # Reduce datetimes to UNIX timestamps
         for k, v in self.api_filters.items():
             if isinstance(v, datetime):
-                self.api_filters[k] = int(time.mktime(v.timetuple()))
+                self.api_filters[k] = int(calendar.timegm(v.timetuple()))
 
         filters = '&'.join("%s=%s" % (k, v) for (k, v) in self.api_filters.items())
 

--- a/ripe/atlas/cousteau/__init__.py
+++ b/ripe/atlas/cousteau/__init__.py
@@ -4,6 +4,9 @@ try:
 except ImportError:
     # Python 2
     from urlparse import urlparse
+
+import time
+
 from datetime import datetime
 
 from .measurement import Ping, Traceroute, Dns, Sslcert, Ntp
@@ -152,6 +155,11 @@ class RequestGenerator(object):
         ):
             self.build_url_chunks()
             return self.split_urls.pop(0)
+
+        # Reduce datetimes to UNIX timestamps
+        for k, v in self.api_filters.items():
+            if isinstance(v, datetime):
+                self.api_filters[k] = int(time.mktime(v.timetuple()))
 
         filters = '&'.join("%s=%s" % (k, v) for (k, v) in self.api_filters.items())
 


### PR DESCRIPTION
The API expects UNIX timestamps, but we were sending ISO encoded strings.  This should fix that.