### PR TITLE
Requests complains about old 2.7 versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from os.path import abspath, dirname, join
+from sys import version_info
 from setuptools import setup
 
 # import manually __version__ variable
@@ -16,6 +17,16 @@ tests_require = [
     "mock",
     "jsonschema"
 ]
+
+if version_info.major == 2:
+
+    if version_info.minor < 7:
+        raise NotImplementedError(
+            "This package requires Python 2.7 or higher")
+
+    # See: https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning
+    if version_info.micro < 10:
+        install_requires += ["ndg-httpsclient", "pyasn"]
 
 
 # Get proper long description for package


### PR DESCRIPTION
Running Magellan against older Python2.7 versions (like those using the scl hack on Centos6) spit out this warning on every request:

            /home/dquinn/.virtualenvs/toolkit-test/lib/python2.7/site-packages/requests/packages/urllib3/util/ssl_.py:100: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning.
          InsecurePlatformWarning

According to the URL provided, adding `ndg-httpsclient` and `pyasn` fixes the problem (and silences the warning) so I'm adding the conditional requirement here.

Additionally, as we don't support <2.7, I added a `NotImplementedError` for that case as well.