### PR TITLE
Support changing the user-agent

### DIFF
--- a/ripe/atlas/cousteau/__init__.py
+++ b/ripe/atlas/cousteau/__init__.py
@@ -35,7 +35,7 @@ class EntityRepresentation(object):
         self.id = kwargs.get("id")
         self.api_key = kwargs.get("key", "")
         self.meta_data = kwargs.get("meta_data")
-        self.user_agent = kwargs.get("user_agent")
+        self._user_agent = kwargs.get("user_agent")
 
         if self.meta_data is None and self.id is None:
             raise CousteauGenericError(
@@ -53,7 +53,7 @@ class EntityRepresentation(object):
         is_success, meta_data = AtlasRequest(
             url_path=self.API_META_URL.format(self.id),
             key=self.api_key,
-            user_agent=self.user_agent
+            user_agent=self._user_agent
         ).get()
 
         self.meta_data = meta_data

--- a/ripe/atlas/cousteau/__init__.py
+++ b/ripe/atlas/cousteau/__init__.py
@@ -145,7 +145,8 @@ class RequestGenerator(object):
     id_filter = ""
     URL_LENGTH_LIMIT = 5000
 
-    def __init__(self, return_objects=False, **filters):
+    def __init__(self, return_objects=False, user_agent=None, **filters):
+        self._user_agent = user_agent
         self.api_filters = filters
         self.split_urls = []
         self.total_count_flag = False
@@ -227,7 +228,8 @@ class RequestGenerator(object):
         Querying API for the next batch of objects and store next url and
         batch of objects.
         """
-        is_success, results = AtlasRequest(**{"url_path": self.atlas_url}).get()
+        is_success, results = AtlasRequest(
+            url_path=self.atlas_url, user_agent=self._user_agent).get()
 
         if not is_success:
             raise APIResponseError(results)

--- a/ripe/atlas/cousteau/__init__.py
+++ b/ripe/atlas/cousteau/__init__.py
@@ -32,9 +32,10 @@ class EntityRepresentation(object):
 
     def __init__(self, **kwargs):
 
-        self.id = kwargs.get("id", None)
+        self.id = kwargs.get("id")
         self.api_key = kwargs.get("key", "")
-        self.meta_data = kwargs.get("meta_data", None)
+        self.meta_data = kwargs.get("meta_data")
+        self.user_agent = kwargs.get("user_agent")
 
         if self.meta_data is None and self.id is None:
             raise CousteauGenericError(
@@ -50,7 +51,9 @@ class EntityRepresentation(object):
     def _fetch_meta_data(self):
         """Makes an API call to fetch meta data for the given probe and stores the raw data."""
         is_success, meta_data = AtlasRequest(
-            **{"url_path": self.API_META_URL.format(self.id), "key": self.api_key}
+            url_path=self.API_META_URL.format(self.id),
+            key=self.api_key,
+            user_agent=self.user_agent
         ).get()
 
         self.meta_data = meta_data
@@ -60,7 +63,9 @@ class EntityRepresentation(object):
         return True
 
     def _populate_data(self):
-        """Assing some raw meta data from API response to instance properties"""
+        """
+        Passing some raw meta data from API response to instance properties
+        """
         raise NotImplementedError()
 
     def __str__(self):

--- a/ripe/atlas/cousteau/request.py
+++ b/ripe/atlas/cousteau/request.py
@@ -24,17 +24,14 @@ class AtlasRequest(object):
     }
 
     def __init__(self, **kwargs):
-        self.url = ""
-        self.url_path = ""
-        self.key = kwargs.get("key", None)
-        if "url_path" in kwargs:
-            self.url_path = kwargs["url_path"]
-        if "server" in kwargs:
-            self.server = kwargs["server"]
-        else:
-            self.server = "atlas.ripe.net"
 
-        self.http_agent = "RIPE ATLAS Cousteau v{0}".format(__version__)
+        self.url = ""
+        self.key = kwargs.get("key")
+        self.url_path = kwargs.get("url_path", "")
+        self.server = kwargs.get("server", "atlas.ripe.net")
+
+        default_user_agent = "RIPE ATLAS Cousteau v{0}".format(__version__)
+        self.http_agent = kwargs.get("user_agent") or default_user_agent
 
         self.http_method_args = {
             "params": {"key": self.key},

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -385,13 +385,13 @@ class TestRequestGenerator(unittest.TestCase):
         kwargs = {"limit": "100", "asn": "3333"}
         r = RequestGenerator(**kwargs)
         self.assertEqual(
-            decostruct_url_params(r.build_url()), set(["limit=100", "asn=3333"])
+            decostruct_url_params(r.build_url()), {"limit=100", "asn=3333"}
         )
         kwargs = {"limit": "100", "asn": "3333", "tags": "NAT,system-ipv4-works"}
         r = RequestGenerator(**kwargs)
         self.assertEqual(
             decostruct_url_params(r.build_url()),
-            set(["limit=100", "tags=NAT,system-ipv4-works", "asn=3333"])
+            {"limit=100", "tags=NAT,system-ipv4-works", "asn=3333"}
         )
         kwargs = {"asn": "3333"}
         r = RequestGenerator(**kwargs)
@@ -704,6 +704,10 @@ class TestRequestGenerator(unittest.TestCase):
 
         self.assertEqual(probes_list, expected_value)
         self.assertEqual(probe_generator.total_count, 6)
+
+    def test_user_agent(self):
+        self.assertEqual(RequestGenerator()._user_agent, None)
+        self.assertEqual(RequestGenerator(user_agent="x")._user_agent, "x")
 
     def tearDown(self):
         mock.patch.stopall()

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -385,13 +385,13 @@ class TestRequestGenerator(unittest.TestCase):
         kwargs = {"limit": "100", "asn": "3333"}
         r = RequestGenerator(**kwargs)
         self.assertEqual(
-            decostruct_url_params(r.build_url()), {"limit=100", "asn=3333"}
+            decostruct_url_params(r.build_url()), set(["limit=100", "asn=3333"])
         )
         kwargs = {"limit": "100", "asn": "3333", "tags": "NAT,system-ipv4-works"}
         r = RequestGenerator(**kwargs)
         self.assertEqual(
             decostruct_url_params(r.build_url()),
-            {"limit=100", "tags=NAT,system-ipv4-works", "asn=3333"}
+            set(["limit=100", "tags=NAT,system-ipv4-works", "asn=3333"])
         )
         kwargs = {"asn": "3333"}
         r = RequestGenerator(**kwargs)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -759,20 +759,18 @@ class TestProbeRepresentation(unittest.TestCase):
     def test_user_agent(self):
 
         paths = {
-            "version": "ripe.atlas.cousteau.request.__version__",
             "fetch": "ripe.atlas.cousteau.Probe._fetch_meta_data",
             "populate": "ripe.atlas.cousteau.Probe._populate_data",
         }
 
-        with mock.patch(paths["version"], 999):
-            with mock.patch(paths["fetch"]) as fetch:
-                fetch.return_value = True
-                with mock.patch(paths["populate"]):
-                    self.assertEqual(Probe(id=1)._user_agent, None)
-                    self.assertEqual(
-                        Probe(id=1, user_agent=None)._user_agent, None)
-                    self.assertEqual(
-                        Probe(id=1, user_agent="w00t")._user_agent, "w00t")
+        with mock.patch(paths["fetch"]) as fetch:
+            fetch.return_value = True
+            with mock.patch(paths["populate"]):
+                self.assertEqual(Probe(id=1)._user_agent, None)
+                self.assertEqual(
+                    Probe(id=1, user_agent=None)._user_agent, None)
+                self.assertEqual(
+                    Probe(id=1, user_agent="w00t")._user_agent, "w00t")
 
 
 class TestMeasurementRepresentation(unittest.TestCase):
@@ -824,17 +822,15 @@ class TestMeasurementRepresentation(unittest.TestCase):
     def test_user_agent(self):
 
         paths = {
-            "version": "ripe.atlas.cousteau.request.__version__",
             "fetch": "ripe.atlas.cousteau.Measurement._fetch_meta_data",
             "populate": "ripe.atlas.cousteau.Measurement._populate_data",
         }
 
-        with mock.patch(paths["version"], 999):
-            with mock.patch(paths["fetch"]) as fetch:
-                fetch.return_value = True
-                with mock.patch(paths["populate"]):
-                    self.assertEqual(Measurement(id=1)._user_agent, None)
-                    self.assertEqual(
-                        Measurement(id=1, user_agent=None)._user_agent, None)
-                    self.assertEqual(
-                        Measurement(id=1, user_agent="w00t")._user_agent, "w00t")
+        with mock.patch(paths["fetch"]) as fetch:
+            fetch.return_value = True
+            with mock.patch(paths["populate"]):
+                self.assertEqual(Measurement(id=1)._user_agent, None)
+                self.assertEqual(
+                    Measurement(id=1, user_agent=None)._user_agent, None)
+                self.assertEqual(
+                    Measurement(id=1, user_agent="w00t")._user_agent, "w00t")

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -126,6 +126,13 @@ class TestAtlasRequest(unittest.TestCase):
                 (False, ("excargs",))
             )
 
+    def test_user_agent(self):
+        with mock.patch("ripe.atlas.cousteau.request.__version__", 999):
+            standard = "RIPE ATLAS Cousteau v999"
+            self.assertEqual(AtlasRequest().http_agent, standard)
+            self.assertEqual(AtlasRequest(user_agent=None).http_agent, standard)
+            self.assertEqual(AtlasRequest(user_agent="w00t"), "w00t")
+
 
 class TestAtlasCreateRequest(unittest.TestCase):
     def setUp(self):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -815,8 +815,8 @@ class TestMeasurementRepresentation(unittest.TestCase):
             with mock.patch(paths["fetch"]) as fetch:
                 fetch.return_value = True
                 with mock.patch(paths["populate"]):
-                    self.assertEqual(Measurement(id=1).user_agent, None)
+                    self.assertEqual(Measurement(id=1)._user_agent, None)
                     self.assertEqual(
-                        Measurement(id=1, user_agent=None).user_agent, None)
+                        Measurement(id=1, user_agent=None)._user_agent, None)
                     self.assertEqual(
-                        Measurement(id=1, user_agent="w00t").user_agent, "w00t")
+                        Measurement(id=1, user_agent="w00t")._user_agent, "w00t")

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -131,7 +131,7 @@ class TestAtlasRequest(unittest.TestCase):
             standard = "RIPE ATLAS Cousteau v999"
             self.assertEqual(AtlasRequest().http_agent, standard)
             self.assertEqual(AtlasRequest(user_agent=None).http_agent, standard)
-            self.assertEqual(AtlasRequest(user_agent="w00t"), "w00t")
+            self.assertEqual(AtlasRequest(user_agent="w00t").http_agent, "w00t")
 
 
 class TestAtlasCreateRequest(unittest.TestCase):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -756,6 +756,24 @@ class TestProbeRepresentation(unittest.TestCase):
             request_mock.return_value = False, {}
             self.assertRaises(APIResponseError, lambda: Probe(id=1))
 
+    def test_user_agent(self):
+
+        paths = {
+            "version": "ripe.atlas.cousteau.request.__version__",
+            "fetch": "ripe.atlas.cousteau.Probe._fetch_meta_data",
+            "populate": "ripe.atlas.cousteau.Probe._populate_data",
+        }
+
+        with mock.patch(paths["version"], 999):
+            with mock.patch(paths["fetch"]) as fetch:
+                fetch.return_value = True
+                with mock.patch(paths["populate"]):
+                    self.assertEqual(Probe(id=1)._user_agent, None)
+                    self.assertEqual(
+                        Probe(id=1, user_agent=None)._user_agent, None)
+                    self.assertEqual(
+                        Probe(id=1, user_agent="w00t")._user_agent, "w00t")
+
 
 class TestMeasurementRepresentation(unittest.TestCase):
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -758,6 +758,7 @@ class TestProbeRepresentation(unittest.TestCase):
 
 
 class TestMeasurementRepresentation(unittest.TestCase):
+
     def test_sane_response(self):
         with mock.patch('ripe.atlas.cousteau.request.AtlasRequest.get') as request_mock:
             resp = {
@@ -801,3 +802,21 @@ class TestMeasurementRepresentation(unittest.TestCase):
         with mock.patch('ripe.atlas.cousteau.request.AtlasRequest.get') as request_mock:
             request_mock.return_value = False, {}
             self.assertRaises(APIResponseError, lambda: Measurement(id=1))
+
+    def test_user_agent(self):
+
+        paths = {
+            "version": "ripe.atlas.cousteau.request.__version__",
+            "fetch": "ripe.atlas.cousteau.Measurement._fetch_meta_data",
+            "populate": "ripe.atlas.cousteau.Measurement._populate_data",
+        }
+
+        with mock.patch(paths["version"], 999):
+            with mock.patch(paths["fetch"]) as fetch:
+                fetch.return_value = True
+                with mock.patch(paths["populate"]):
+                    self.assertEqual(Measurement(id=1).user_agent, None)
+                    self.assertEqual(
+                        Measurement(id=1, user_agent=None).user_agent, None)
+                    self.assertEqual(
+                        Measurement(id=1, user_agent="w00t").user_agent, "w00t")


### PR DESCRIPTION
It's a pretty simple change, but I took the opportunity to unify the styles in the __init__.  We had some cases of using `kwargs.get()` and others doing deliberate testing of `x in kwargs` -- as they're semantically the same, but weren't literally the same.

Note that the `user_agent` bit there is using `default_user_agent` because it's possible that `user_agent=None` and we don't want to deal with that further down the pipe so we just force the default.

Closes #15