### PR TITLE
Add tests to the pypi package for packagers

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include README.rst
 include MANIFEST.in
 include CHANGES.rst
 recursive-include ripe *
+recursive-include tests *


### PR DESCRIPTION
I had a conversation with the Gentoo guys today and they were *really* surprised that the tests weren't installed as part of the tarball.  It makes it difficult for packagers to do their thing if there aren't any tests in the package and they depend on using GitHub's sources to do them in their own environments.

Anyway, their request was to add them, and since I see no problem with that, I'm pretty sure that this'll do the trick.  I'm replicating this PR for Sagan & Magellan as well.