### PR TITLE
Renamed destination_* to target* in line with the final names in the …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,15 @@
 Releases History
 ================
+1.2 (released 2016-02-26)
+-------------------------
+Changes:
+~~~~~~~~
+- Backwards incompatible field changes on the Measurement object:
+
+ - destination_address -> target_ip
+ - destination_asn -> target_asn
+ - destination_name -> target
+
 1.1 (released 2016-02-09)
 -------------------------
 New features:

--- a/README.rst
+++ b/README.rst
@@ -276,8 +276,8 @@ Every time you create a new instance it will fetch meta data from API and return
     print(measurement.description)
     print(measurement.is_oneoff)
     print(measurement.is_public)
-    print(measurement.destination_address)
-    print(measurement.destination_asn)
+    print(measurement.target_ip)
+    print(measurement.target_asn)
     print(measurement.type)
     print(measurement.interval)
     print(dir(measurement)) # Full list of properties

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -394,8 +394,8 @@ Example:
     print(measurement.description)
     print(measurement.is_oneoff)
     print(measurement.is_public)
-    print(measurement.destination_address)
-    print(measurement.destination_asn)
+    print(measurement.target_ip)
+    print(measurement.target_asn)
     print(measurement.type)
     print(measurement.interval)
     print(dir(measurement)) # Full list of properties

--- a/ripe/atlas/cousteau/api_meta_data.py
+++ b/ripe/atlas/cousteau/api_meta_data.py
@@ -127,9 +127,9 @@ class Measurement(EntityRepresentation):
         self.start_time = None
         self.populate_times()
         self.protocol = self.meta_data.get("af")
-        self.destination_address = self.meta_data.get("destination_address")
-        self.destination_asn = self.meta_data.get("destination_asn")
-        self.destination_name = self.meta_data.get("destination_name")
+        self.target_ip = self.meta_data.get("target_ip")
+        self.target_asn = self.meta_data.get("target_asn")
+        self.target = self.meta_data.get("target")
         self.description = self.meta_data.get("description")
         self.is_oneoff = self.meta_data.get("is_oneoff")
         self.is_public = self.meta_data.get("is_public")

--- a/tests/test_api_meta_data.py
+++ b/tests/test_api_meta_data.py
@@ -106,9 +106,9 @@ class TestMeasurementRepresentation(TestCase):
     def setUp(self):
         self.resp = {
             "af": 4,
-            "destination_address": "202.73.56.70",
-            "destination_asn": 9255,
-            "destination_name": "blaaaah",
+            "target_ip": "202.73.56.70",
+            "target_asn": 9255,
+            "target": "blaaaah",
             "msm_id": 2310448,
             "description": "Blaaaaaaaaaah",
             "is_oneoff": True,
@@ -130,9 +130,9 @@ class TestMeasurementRepresentation(TestCase):
             measurement = Measurement(id=1)
             self.assertEqual(measurement.meta_data, self.resp)
             self.assertEqual(measurement.protocol, 4)
-            self.assertEqual(measurement.destination_address, "202.73.56.70")
-            self.assertEqual(measurement.destination_asn, 9255)
-            self.assertEqual(measurement.destination_name, "blaaaah")
+            self.assertEqual(measurement.target_ip, "202.73.56.70")
+            self.assertEqual(measurement.target_asn, 9255)
+            self.assertEqual(measurement.target, "blaaaah")
             self.assertEqual(measurement.description, "Blaaaaaaaaaah")
             self.assertEqual(measurement.is_oneoff, True)
             self.assertEqual(measurement.is_public, True)


### PR DESCRIPTION
Updated to use the final names for the target/destination fields in the v2 API:

target           the specified target (may be an IP address or a hostname)
target_ip      the validated/resolved IP address
target_asn   the originating ASN for the routed prefix containing the target_ip