### PR TITLE
Add ability to provide custom headers and proxies

### DIFF
--- a/ripe/atlas/cousteau/request.py
+++ b/ripe/atlas/cousteau/request.py
@@ -45,6 +45,8 @@ class AtlasRequest(object):
         self.url_path = kwargs.get("url_path", "")
         self.server = kwargs.get("server") or "atlas.ripe.net"
         self.verify = kwargs.get("verify", True)
+        self.proxies = kwargs.get("proxies", {})
+        self.headers = kwargs.get("headers", None)
 
         default_user_agent = "RIPE ATLAS Cousteau v{0}".format(__version__)
         self.http_agent = kwargs.get("user_agent") or default_user_agent
@@ -52,17 +54,23 @@ class AtlasRequest(object):
         self.http_method_args = {
             "params": {"key": self.key},
             "headers": self.get_headers(),
-            "verify": self.verify
+            "verify": self.verify,
+            "proxies": self.proxies
         }
+
         self.post_data = {}
 
     def get_headers(self):
         """Return header for the HTTP request."""
-        return {
+        headers = {
             "User-Agent": self.http_agent,
             "Content-Type": "application/json",
             "Accept": "application/json"
         }
+        if self.headers:
+            headers.update(self.headers)
+
+        return headers
 
     def http_method(self, method):
         """

--- a/ripe/atlas/cousteau/stream.py
+++ b/ripe/atlas/cousteau/stream.py
@@ -27,11 +27,14 @@ class AtlasStream(object):
         "error": CHANNEL_ERROR,
     }
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         """Initialize stream"""
 
         self.iosocket_server = "atlas-stream.ripe.net"
         self.iosocket_resource = "/stream/socket.io"
+
+        self.proxies = kwargs.get("proxies", {})
+        self.headers = kwargs.get("headers", {})
 
         self.socketIO = None
 
@@ -41,7 +44,9 @@ class AtlasStream(object):
             host=self.iosocket_server,
             port=80,
             resource=self.iosocket_resource,
-            transports=["websocket"]
+            transports=["websocket"],
+            proxies=self.proxies,
+            headers=self.headers
         )
 
     def disconnect(self):


### PR DESCRIPTION
# Changes
* Add ability to provide headers/proxies when setting up `AtlasRequest` and `AtlasStream` objects
* Default to previous behaviour if one or the other are not provided

# Tested
- [x] Tested with custom headers
- [x] Tested with custom proxies
- [x] Tested without headers
- [x] Tested without proxies

Fixes #28 