### PR TITLE
DAR-2731: [Cousteau] should listening to the errors by default

### DIFF
--- a/ripe/atlas/cousteau/stream.py
+++ b/ripe/atlas/cousteau/stream.py
@@ -41,7 +41,7 @@ class AtlasStream(object):
         if self.error_callback:
             self.error_callback(error)
         elif self.log_errors:
-            print error
+            print(error)
 
     def connect(self):
         """Initiate the channel we want to start streams from."""
@@ -72,12 +72,10 @@ class AtlasStream(object):
 
     def start_stream(self, stream_type, **stream_parameters):
         """Starts new stream for given type with given parameters"""
-        # if stream_type in ("result", "probestatus"):
         if stream_type:
             self.subscribe(stream_type, **stream_parameters)
         else:
             print("You need to set a stream type")
-            # print("Given stream type: <{0}> is not valid".format(stream_type))
 
     def subscribe(self, stream_type, **parameters):
         """Subscribe to stream with give parameters."""


### PR DESCRIPTION
Cousteau now listens to the errors by default. It allows the user to disable the logging or to specify a callback to handle them.