### PR TITLE
Metadata with UTC timezone aware objects.

### DIFF
--- a/ripe/atlas/cousteau/api_meta_data.py
+++ b/ripe/atlas/cousteau/api_meta_data.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from datetime import datetime
+from dateutil.tz import tzutc
 
 from .request import AtlasRequest
 from .exceptions import CousteauGenericError, APIResponseError
@@ -164,15 +165,18 @@ class Measurement(EntityRepresentation):
         """
         stop_time = self.meta_data.get("stop_time")
         if stop_time:
-            self.stop_time = datetime.fromtimestamp(stop_time)
+            stop_naive = datetime.utcfromtimestamp(stop_time)
+            self.stop_time = stop_naive.replace(tzinfo=tzutc())
 
         creation_time = self.meta_data.get("creation_time")
         if creation_time:
-            self.creation_time = datetime.fromtimestamp(creation_time)
+            creation_naive = datetime.utcfromtimestamp(creation_time)
+            self.creation_time = creation_naive.replace(tzinfo=tzutc())
 
         start_time = self.meta_data.get("start_time")
         if start_time:
-            self.start_time = datetime.fromtimestamp(start_time)
+            start_naive = datetime.utcfromtimestamp(start_time)
+            self.start_time = start_naive.replace(tzinfo=tzutc())
 
     def __str__(self):
         return "Measurement #{0}".format(self.id)

--- a/tests/test_api_meta_data.py
+++ b/tests/test_api_meta_data.py
@@ -20,6 +20,7 @@ except ImportError:
     import mock
 from unittest import TestCase
 from datetime import datetime
+from dateutil.tz import tzutc
 
 from ripe.atlas.cousteau import Probe, Measurement
 from ripe.atlas.cousteau.exceptions import APIResponseError
@@ -138,9 +139,9 @@ class TestMeasurementRepresentation(TestCase):
             self.assertEqual(measurement.is_public, True)
             self.assertEqual(measurement.interval, 1800)
             self.assertEqual(measurement.status, "Stopped")
-            self.assertEqual(measurement.creation_time, datetime.fromtimestamp(1439379910))
-            self.assertEqual(measurement.start_time, datetime.fromtimestamp(1439379910))
-            self.assertEqual(measurement.stop_time, datetime.fromtimestamp(1439380502))
+            self.assertEqual(measurement.creation_time, datetime.utcfromtimestamp(1439379910).replace(tzinfo=tzutc()))
+            self.assertEqual(measurement.start_time, datetime.utcfromtimestamp(1439379910).replace(tzinfo=tzutc()))
+            self.assertEqual(measurement.stop_time, datetime.utcfromtimestamp(1439380502).replace(tzinfo=tzutc()))
             self.assertEqual(measurement.type, "HTTP")
             self.assertEqual(measurement.result_url, "/api/v1/measurement/2310448/result/")
 


### PR DESCRIPTION
Hello.
I used `utcfromtimestamp()` and `dateutil`'s `replace()` to get timezone awareness. I changed it in `populatate_times()` and in the tests (using the same code, so it might not actually test these functions). 
I tested it and I'm using this version.
Thank you.