### PR TITLE
add exceptions cousteaus API

### DIFF
--- a/ripe/atlas/cousteau/__init__.py
+++ b/ripe/atlas/cousteau/__init__.py
@@ -25,6 +25,7 @@ from .request import (
 from .stream import AtlasStream
 from .api_listing import ProbeRequest, MeasurementRequest, AnchorRequest
 from .api_meta_data import Probe, Measurement
+from .exceptions import CousteauGenericError, APIResponseError
 
 
 __all__ = [
@@ -47,5 +48,7 @@ __all__ = [
     "MeasurementRequest",
     "AnchorRequest",
     "Probe",
-    "Measurement"
+    "Measurement",
+    "CousteauGenericError",
+    "APIResponseError"
 ]


### PR DESCRIPTION
I need to differentiate between cousteau errors and others. That's why I added them to the init.py so they can be accessed