### PR TITLE
Allow multiple measurement IDs for AtlasResultsRequest 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ exec(open('ripe/atlas/cousteau/version.py').read())
 
 install_requires = [
     "python-dateutil", "socketIO-client>=0.6.5",
-    "requests>=2.7.0", "websocket-client<0.99"
+    "requests>=2.7.0", "websocket-client<0.99",
+    "grequests"
 ]
 
 tests_require = [


### PR DESCRIPTION
Fetching results from multiple measurements can get quite slow if there is a lot of measurements... so I modified the code to fetch data in parallel using grequests. It is much faster than the original code. Requesting results from 10 different measurements is 10 times faster :)
There shouldn't be any backward incompatibility.