### PR TITLE
Update use.rst

### DIFF
--- a/docs/use.rst
+++ b/docs/use.rst
@@ -135,7 +135,6 @@ Examples:
 
 
     atlas_request = AtlasCreateRequest(
-        start_time=datetime.utcnow(),
         key=ATLAS_API_KEY,
         measurements=[ping, traceroute],
         sources=[source, source1],


### PR DESCRIPTION
With "start_time=datetime.utcnow()" the example sometimes will fail to start, especially if the user is far from the RIPE Atlas server: due to the network delay the start_time will be in the past:

{'error': {'status': 400, 'errors': [{'source': {'pointer': '/definitions/0/start_time'}, 'detail': 'Measurements must have the start time in future'}], 'code': 102, 'detail': 'There was a problem with your request', 'title': 'Bad Request'}}

However, missing start_time means "run now", so this string can be simply omitted.