### PR TITLE
Only require funcsigs for Python < 3.3 (they are included in 3.3+)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
 ]
 
 tests_require = [
-    "funcsigs",
+    'funcsigs;python_version<"3.3"',
     "setuptools",
     "nose",
     "coverage",


### PR DESCRIPTION
Only require funcsigs for Python <3.3