### PR TITLE
Move from the deprecated assertEquals to assertEqual

### DIFF
--- a/tests/test_api_listing.py
+++ b/tests/test_api_listing.py
@@ -373,21 +373,21 @@ class TestRequestGenerator(TestCase):
 class TestProbeRequestGenerator(TestCase):
     def test_url(self):
         gen = ProbeRequest()
-        self.assertEquals(gen.url, "/api/v2/probes/")
+        self.assertEqual(gen.url, "/api/v2/probes/")
 
     def test_id_filter(self):
         gen = ProbeRequest()
-        self.assertEquals(gen.id_filter, "id__in")
+        self.assertEqual(gen.id_filter, "id__in")
 
 
 class TestMeasurementRequestGenerator(TestCase):
     def test_url(self):
         gen = MeasurementRequest(return_objects=True)
-        self.assertEquals(gen.url, "/api/v2/measurements/")
+        self.assertEqual(gen.url, "/api/v2/measurements/")
 
     def test_id_filter(self):
         gen = MeasurementRequest()
-        self.assertEquals(gen.id_filter, "id__in")
+        self.assertEqual(gen.id_filter, "id__in")
 
 
 class TestAnchorRequestGenerator(TestCase):
@@ -397,8 +397,8 @@ class TestAnchorRequestGenerator(TestCase):
 
     def test_url(self):
         gen = AnchorRequest(return_objects=True)
-        self.assertEquals(gen.url, "/api/v2/anchors/")
+        self.assertEqual(gen.url, "/api/v2/anchors/")
 
     def test_id_filter(self):
         gen = AnchorRequest()
-        self.assertEquals(gen.id_filter, "id__in")
+        self.assertEqual(gen.id_filter, "id__in")

--- a/tests/test_api_meta_data.py
+++ b/tests/test_api_meta_data.py
@@ -93,13 +93,13 @@ class TestProbeRepresentation(TestCase):
         with mock.patch('ripe.atlas.cousteau.request.AtlasRequest.get') as request_mock:
             request_mock.return_value = True, {}
             Probe(id=1, fields=["probes"])
-            self.assertEquals(request_mock.call_args[1], {"fields": "probes"})
+            self.assertEqual(request_mock.call_args[1], {"fields": "probes"})
             Probe(id=1, fields=["probes", "data"])
-            self.assertEquals(request_mock.call_args[1], {"fields": "probes,data"})
+            self.assertEqual(request_mock.call_args[1], {"fields": "probes,data"})
             Probe(id=1, fields="probes,data")
-            self.assertEquals(request_mock.call_args[1], {"fields": "probes,data"})
+            self.assertEqual(request_mock.call_args[1], {"fields": "probes,data"})
             Probe(id=1, fields=1)
-            self.assertEquals(request_mock.call_args[1], {})
+            self.assertEqual(request_mock.call_args[1], {})
 
 
 class TestMeasurementRepresentation(TestCase):
@@ -191,13 +191,13 @@ class TestMeasurementRepresentation(TestCase):
         with mock.patch('ripe.atlas.cousteau.request.AtlasRequest.get') as request_mock:
             request_mock.return_value = True, {}
             Measurement(id=1, fields=["probes"])
-            self.assertEquals(request_mock.call_args[1], {"fields": "probes"})
+            self.assertEqual(request_mock.call_args[1], {"fields": "probes"})
             Measurement(id=1, fields=["probes", "data"])
-            self.assertEquals(request_mock.call_args[1], {"fields": "probes,data"})
+            self.assertEqual(request_mock.call_args[1], {"fields": "probes,data"})
             Measurement(id=1, fields="probes,data")
-            self.assertEquals(request_mock.call_args[1], {"fields": "probes,data"})
+            self.assertEqual(request_mock.call_args[1], {"fields": "probes,data"})
             Measurement(id=1, fields=1)
-            self.assertEquals(request_mock.call_args[1], {})
+            self.assertEqual(request_mock.call_args[1], {})
 
     def test_populate_times(self):
         with mock.patch('ripe.atlas.cousteau.request.AtlasRequest.get') as request_mock:


### PR DESCRIPTION
assertEquals is deprecated and throws a bunch of warnings saying as much.

This is a simple move to assertEqual